### PR TITLE
docs: add project and component documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,67 @@
-# React + TypeScript + Vite
+# Mayar & Aly Wedding Website
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+An interactive React + TypeScript project built with Vite to celebrate
+the story of Mayar and Aly. The site combines animations, 3D models and
+rich media to create an engaging experience.
 
-Currently, two official plugins are available:
+## Features
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- Smooth scrolling sections powered by GSAP
+- Animated sunflower cursor trail
+- Photo timelines and gallery carousels
+- Interactive chat replays
+- Mapbox view of where the couple first met
+- 3D sunflower model with scroll-triggered animation
+- Countdown timers to the wedding day
+- Password gate for private access
 
-## Expanding the ESLint configuration
+## Getting Started
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+### Prerequisites
 
-```js
-export default tseslint.config({
-  extends: [
-    // Remove ...tseslint.configs.recommended and replace with this
-    ...tseslint.configs.recommendedTypeChecked,
-    // Alternatively, use this for stricter rules
-    ...tseslint.configs.strictTypeChecked,
-    // Optionally, add this for stylistic rules
-    ...tseslint.configs.stylisticTypeChecked,
-  ],
-  languageOptions: {
-    // other options...
-    parserOptions: {
-      project: ['./tsconfig.node.json', './tsconfig.app.json'],
-      tsconfigRootDir: import.meta.dirname,
-    },
-  },
-})
+- Node.js 18+
+- npm
+
+### Install dependencies
+
+```bash
+npm install
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+### Run the development server
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
-
-export default tseslint.config({
-  plugins: {
-    // Add the react-x and react-dom plugins
-    'react-x': reactX,
-    'react-dom': reactDom,
-  },
-  rules: {
-    // other rules...
-    // Enable its recommended typescript rules
-    ...reactX.configs['recommended-typescript'].rules,
-    ...reactDom.configs.recommended.rules,
-  },
-})
+```bash
+npm run dev
 ```
+
+### Build for production
+
+```bash
+npm run build
+```
+
+### Lint the source code
+
+```bash
+npm run lint
+```
+
+### Preview the production build
+
+```bash
+npm run preview
+```
+
+## Project Structure
+
+```
+src/
+  components/        # Reusable UI components
+  assets/            # Static assets
+  App.tsx            # Main application
+  main.tsx           # Entry point
+```
+
+See [docs/components.md](docs/components.md) for detailed component
+documentation.
+

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,0 +1,32 @@
+# Component Overview
+
+Brief descriptions of the main React components used in this project.
+
+- **CursorEffect** – Spawns a sunflower trail that follows the mouse
+  pointer.
+- **FlipCountdown** – Flip-style animation countdown to 26 December 2025.
+- **CountdownTimer** – Simple numeric countdown timer for the wedding
+  date.
+- **GalleryCarousel** – Autoplaying image carousel built with
+  `react-slick`.
+- **PhotoTimeline** – GSAP-powered horizontally scrolling timeline of
+  photos.
+- **PhotoTimelineOld** – Alternate timeline showcasing older memories.
+- **FakeChat** – Renders timed chat messages (text or images) to mimic a
+  real conversation.
+- **FakeChatSlider** – Swipeable slider that cycles through multiple
+  `FakeChat` conversations.
+- **LoadingScreen** – Fullscreen loader displayed while assets are
+  fetched.
+- **WebARScene** – Basic Three.js scene set up for WebAR content.
+- **FirstMeetMap** – Mapbox map that zooms to the location where the
+  couple first met.
+- **SmoothScroll** – Wrapper component enabling scroll-triggered section
+  pinning via GSAP.
+- **Timeline** – Interactive milestone timeline with modal details for
+  each event.
+- **ThreeJSModel** – Scroll-animated 3D sunflower rendered with
+  Three.js.
+- **PasswordGate** – Simple password gate that stores authentication in
+  `localStorage`.
+


### PR DESCRIPTION
## Summary
- replace template README with project overview, setup instructions, and structure
- document React components such as CursorEffect, FlipCountdown, and FakeChat

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 23 errors, 8 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689c933704b88323bba25abe986b0830